### PR TITLE
fix(*): fix wrong message for mismatching states

### DIFF
--- a/jasmine-es6-promise-matchers.js
+++ b/jasmine-es6-promise-matchers.js
@@ -73,7 +73,7 @@
   var verifyState = function(actualState, expectedState) {
     return {
       pass: actualState === expectedState,
-      message: 'Expected promise to be ' + actualState + ' but it was ' + expectedState + ' instead'
+      message: 'Expected promise to be ' + expectedState + ' but it was ' + actualState + ' instead'
     };
   };
 


### PR DESCRIPTION
When a promise was resolved/rejected in a different state
other than expected, a wrong message was displayed.

E.g. 'Expected promise to be resolved but it was rejected instead'
should be the other way around.